### PR TITLE
fix: crash when setting final exam max marks

### DIFF
--- a/core/src/main/java/com/hussienFahmy/core/data/local/SubjectDao.kt
+++ b/core/src/main/java/com/hussienFahmy/core/data/local/SubjectDao.kt
@@ -120,6 +120,12 @@ interface SubjectDao {
     fun getAllCurrentSubjects(): Flow<List<Subject>>
 
     /**
+     * Get a single subject by id (null if not found)
+     */
+    @Query("SELECT * FROM subject WHERE id = :id")
+    suspend fun getSubjectById(id: Long): Subject?
+
+    /**
      * Get all subjects belonging to a specific archived semester
      */
     @Query("SELECT * FROM subject WHERE semesterId = :semesterId ORDER BY creditHours DESC")
@@ -183,6 +189,11 @@ interface SubjectDao {
 
                             gradesForMax.filter { it.percentage!! <= threshold }
                                 .maxByOrNull { it.percentage!! }
+                            // threshold can fall below the lowest grade (e.g. a
+                            // tiny final-exam weight). Fall back to the lowest
+                            // available grade instead of crashing on maxGrade!!.
+                                ?: gradesForMax.minByOrNull { it.percentage!! }
+                                ?: highestGrade
                         }
 
                     val assignedGrade = subject.gradeName?.let { gradeName ->

--- a/core/src/main/res/values-ar/strings.xml
+++ b/core/src/main/res/values-ar/strings.xml
@@ -182,9 +182,13 @@
     <!-- Final exam strings -->
     <string name="final_exam">الامتحان النهائي</string>
     <string name="final_exam_total_hint">الدرجة الكلية للامتحان النهائي</string>
-    <string name="final_exam_description">أدخل الدرجة الكلية للامتحان النهائي (مثال: ٦٠) وليس ما حصلت عليه فيه. نستخدمها لنُظهر أعلى تقدير لا يزال بإمكانك تحقيقه.</string>
+    <string name="final_exam_description_prefix">أدخل الدرجة الكلية للامتحان النهائي (مثال: ٦٠) —</string>
+    <string name="final_exam_description_emphasis">وليست درجتك التي حصلت عليها.</string>
+    <string name="final_exam_description_suffix">تُستخدم لإظهار أعلى تقدير لا يزال بإمكانك تحقيقه.</string>
     <string name="final_exam_label">الامتحان النهائي من أصل</string>
     <string name="err_subject_final_exam_invalid">يجب أن تكون درجة الامتحان النهائي أكبر من الصفر</string>
+    <string name="err_subject_final_exam_exceeds_total">لا يمكن أن يكون إجمالي الامتحان النهائي أكبر من إجمالي درجات المادة</string>
+    <string name="err_subject_final_exam_below_semester">يجب أن يكون إجمالي الامتحان النهائي أكبر من درجات أعمال السنة التي أدخلتها — أدخل الدرجة الكلية للامتحان، وليس درجتك</string>
     <string name="final_exam_score">درجة الامتحان النهائي</string>
     <string name="semester_work">الأعمال الفصلية</string>
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -34,10 +34,14 @@
     <string name="err_subject_practical_negative">Practical marks can not be less than zero</string>
     <string name="err_subject_project_negative">Project marks can not be less than zero</string>
     <string name="err_subject_final_exam_invalid">Final exam marks must be more than zero</string>
+    <string name="err_subject_final_exam_exceeds_total">Final exam total can\'t be more than the subject total marks</string>
+    <string name="err_subject_final_exam_below_semester">Final exam total must be larger than the semester marks you entered — enter what the exam is out of, not your score</string>
     <string name="final_exam">Final Exam</string>
     <string name="final_exam_total_hint">Max marks for final exam</string>
     <string name="semester_work">Semester Work</string>
-    <string name="final_exam_description">Enter the total marks your final exam is worth (e.g. 60) - not what you scored in it. We use this to show the highest grade you can still achieve.</string>
+    <string name="final_exam_description_prefix">Enter what the final exam is out of (e.g. 60) —</string>
+    <string name="final_exam_description_emphasis">not the score you got.</string>
+    <string name="final_exam_description_suffix">Used to show the highest grade you can still reach.</string>
     <string name="final_exam_label">Final exam out of</string>
     <string name="final_exam_score">Final Exam Score</string>
     <string name="err_subject_total_must_more_than_zero">Total Marks must be more than zero</string>

--- a/core/src/test/java/com/hussienFahmy/core/data/local/SubjectDaoTest.kt
+++ b/core/src/test/java/com/hussienFahmy/core/data/local/SubjectDaoTest.kt
@@ -208,6 +208,22 @@ class SubjectDaoTest {
     }
 
     @Test
+    fun semesterWorkWithLowFinalExamMarks_doesNotCrash() = runTest {
+        // Reproduces crash: student misunderstood the field and entered the
+        // marks they GOT in the final exam (7) instead of what it is OUT OF.
+        // semester: midterm=5 = 5% of 100
+        // finalPercentage = 7/100*100 = 7%
+        // threshold = 5% + 7% = 12% → no non-F grade qualifies (lowest is D=60%)
+        // -> gradesForMax.filter{}.maxByOrNull{} == null -> maxGrade!! crashes
+        subjectDao.updateMidterm(templateSubject.id, 5.0)
+        subjectDao.updateFinalExamMaxMarks(templateSubject.id, 7.0)
+
+        val loaded = subjectDao.subjectsWithAssignedGrade.map { it.toList().first() }.first()
+
+        assertNotNull(loaded.maxGradeCanBeAssigned)
+    }
+
+    @Test
     fun semesterWorkAndMaxGrade() = runTest {
         subjectDao.updateMidterm(templateSubject.id, 5.0)
         subjectDao.updatePractical(templateSubject.id, 10.0)

--- a/semester_marks/semester_marks_domain/src/main/java/com/hussienfahmy/semester_marks_domain/use_case/ChangeFinalExamMaxMarks.kt
+++ b/semester_marks/semester_marks_domain/src/main/java/com/hussienfahmy/semester_marks_domain/use_case/ChangeFinalExamMaxMarks.kt
@@ -10,11 +10,35 @@ class ChangeFinalExamMaxMarks(
 ) {
     suspend operator fun invoke(subjectId: Long, marks: String): UpdateResult {
         val value = marks.toDoubleOrNull()
-        return if (value == null || value <= 0) {
-            UpdateResult.Failed(UiText.StringResource(R.string.err_subject_final_exam_invalid))
-        } else {
-            subjectDao.updateFinalExamMaxMarks(subjectId, value)
-            UpdateResult.Success
+        if (value == null || value <= 0) {
+            return UpdateResult.Failed(UiText.StringResource(R.string.err_subject_final_exam_invalid))
         }
+
+        val subject = subjectDao.getSubjectById(subjectId)
+        if (subject != null) {
+            // final exam total is a portion of the subject total marks
+            if (value > subject.totalMarks) {
+                return UpdateResult.Failed(
+                    UiText.StringResource(R.string.err_subject_final_exam_exceeds_total)
+                )
+            }
+
+            // semester work marks the student has already entered (their scores).
+            // a final-exam total smaller than the coursework scores means the
+            // student typed what they scored in the exam, not what it is out of.
+            val semesterMarks = subject.semesterMarks
+            val semesterWork = (semesterMarks?.midterm ?: 0.0) +
+                    (semesterMarks?.practical ?: 0.0) +
+                    (semesterMarks?.oral ?: 0.0) +
+                    (semesterMarks?.project ?: 0.0)
+            if (semesterWork > 0 && value <= semesterWork) {
+                return UpdateResult.Failed(
+                    UiText.StringResource(R.string.err_subject_final_exam_below_semester)
+                )
+            }
+        }
+
+        subjectDao.updateFinalExamMaxMarks(subjectId, value)
+        return UpdateResult.Success
     }
 }

--- a/semester_marks/semester_marks_presentaion/src/main/java/com/hussienfahmy/semester_marks_presentaion/SemesterMarksScreen.kt
+++ b/semester_marks/semester_marks_presentaion/src/main/java/com/hussienfahmy/semester_marks_presentaion/SemesterMarksScreen.kt
@@ -8,9 +8,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,7 +30,8 @@ fun SemesterMarksScreen(
     modifier: Modifier = Modifier,
     viewModel: SemesterMarksViewModel = koinViewModel(),
 ) {
-    UiEventHandler(uiEvent = viewModel.uiEvent)
+    val snackBarHostState = remember { SnackbarHostState() }
+    UiEventHandler(uiEvent = viewModel.uiEvent, snackBarHostState = snackBarHostState)
 
     val state by viewModel.state
 
@@ -38,13 +42,13 @@ fun SemesterMarksScreen(
         }
     }
 
-    when (val s = state) {
-        is SemesterMarksState.Loading -> Box(modifier = Modifier.fillMaxSize()) {
-            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-        }
+    Box(modifier = Modifier.fillMaxSize()) {
+        when (val s = state) {
+            is SemesterMarksState.Loading ->
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
 
-        is SemesterMarksState.Calculated -> SemesterMarksScreenContent(
-            modifier = modifier,
+            is SemesterMarksState.Calculated -> SemesterMarksScreenContent(
+                modifier = modifier,
             subjects = s.subjects,
             onMidTermMarksChange = { subjectId, marks ->
                 viewModel.onEvent(
@@ -96,6 +100,12 @@ fun SemesterMarksScreen(
                     SemesterMarksEvent.SetProjectAvailability(subjectId, newAvailability)
                 )
             },
+            )
+        }
+
+        SnackbarHost(
+            hostState = snackBarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
         )
     }
 }

--- a/semester_marks/semester_marks_presentaion/src/main/java/com/hussienfahmy/semester_marks_presentaion/SemesterMarksViewModel.kt
+++ b/semester_marks/semester_marks_presentaion/src/main/java/com/hussienfahmy/semester_marks_presentaion/SemesterMarksViewModel.kt
@@ -124,7 +124,7 @@ class SemesterMarksViewModel(
             }
 
             if (result is UpdateResult.Failed) {
-                _uiEvent.send(UiEvent.ShowToast(result.message))
+                _uiEvent.send(UiEvent.ShowSnackBar(result.message))
             }
         }
     }

--- a/semester_marks/semester_marks_presentaion/src/main/java/com/hussienfahmy/semester_marks_presentaion/components/SubjectSettingsBottomSheet.kt
+++ b/semester_marks/semester_marks_presentaion/src/main/java/com/hussienfahmy/semester_marks_presentaion/components/SubjectSettingsBottomSheet.kt
@@ -20,7 +20,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.withStyle
 import com.hussienfahmy.core.R
 import com.hussienfahmy.core_ui.LocalSpacing
 import com.hussienfahmy.core_ui.presentation.components.SemesterMarkChooser
@@ -96,7 +100,20 @@ fun SubjectSettingsBottomSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-                text = stringResource(R.string.final_exam_description),
+                text = buildAnnotatedString {
+                    append(stringResource(R.string.final_exam_description_prefix))
+                    append(" ")
+                    withStyle(
+                        SpanStyle(
+                            color = MaterialTheme.colorScheme.error,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    ) {
+                        append(stringResource(R.string.final_exam_description_emphasis))
+                    }
+                    append(" ")
+                    append(stringResource(R.string.final_exam_description_suffix))
+                },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )


### PR DESCRIPTION
  SubjectDao.subjectsWithAssignedGrade threw NPE when the grade
  threshold fell below the lowest grade (students entered their
  exam score instead of the exam total). Fall back to the lowest
  grade instead of crashing.

  - Validate final exam marks in ChangeFinalExamMaxMarks (reject values above subject total or below entered semester work)
  - Replace truncated toast with snackbar on SemesterMarks screen
  - Clarify final exam field description, highlight "not the score you got" in error color