### PR TITLE
KMP migration Phase 4c: PdfReportPrinter and ReportBrandingProvider expect/actual

### DIFF
--- a/app/src/main/java/com/hussienFahmy/myGpaManager/navigation/screens/AppSemesterHistoryScreen.kt
+++ b/app/src/main/java/com/hussienFahmy/myGpaManager/navigation/screens/AppSemesterHistoryScreen.kt
@@ -2,8 +2,7 @@ package com.hussienfahmy.myGpaManager.navigation.screens
 
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-import com.hussienfahmy.core.domain.report.WebViewPdfPrinter
+import com.hussienfahmy.core.domain.report.createPdfReportPrinter
 import com.hussienfahmy.myGpaManager.navigation.FadeTransitions
 import com.hussienfahmy.semester_history_presentation.SemesterHistoryScreen
 import com.ramcosta.composedestinations.annotation.Destination
@@ -20,8 +19,6 @@ fun AppSemesterHistoryScreen(
     snackBarHostState: SnackbarHostState,
     navigator: DestinationsNavigator,
 ) {
-    val context = LocalContext.current
-
     SemesterHistoryScreen(
         snackBarHostState = snackBarHostState,
         onSemesterClick = { semesterId ->
@@ -30,7 +27,7 @@ fun AppSemesterHistoryScreen(
         onExportHtml = { html ->
             val title =
                 "Academic_Report_${SimpleDateFormat("yyyy-MM-dd_HH-mm", Locale.US).format(Date())}"
-            WebViewPdfPrinter.print(context = context, html = html, title = title)
+            createPdfReportPrinter().print(html = html, title = title)
         },
     )
 }

--- a/core/src/androidMain/kotlin/com/hussienFahmy/core/domain/report/PdfReportPrinter.android.kt
+++ b/core/src/androidMain/kotlin/com/hussienFahmy/core/domain/report/PdfReportPrinter.android.kt
@@ -5,10 +5,10 @@ import android.print.PrintAttributes
 import android.print.PrintManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import org.koin.core.context.GlobalContext
 
-object WebViewPdfPrinter {
-
-    fun print(context: Context, html: String, title: String) {
+actual class PdfReportPrinter(private val context: Context) {
+    actual fun print(html: String, title: String) {
         val webView = WebView(context.applicationContext)
         webView.settings.javaScriptEnabled = false
         webView.webViewClient = object : WebViewClient() {
@@ -26,3 +26,8 @@ object WebViewPdfPrinter {
         webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)
     }
 }
+
+// Same GlobalContext pattern as the other :core factories (getDatabaseBuilder,
+// createImageThumbnailer) - the expect fun signature is shared with the future iOS actual.
+actual fun createPdfReportPrinter(): PdfReportPrinter =
+    PdfReportPrinter(GlobalContext.get().get())

--- a/core/src/androidMain/kotlin/com/hussienFahmy/core/domain/report/ReportBrandingProvider.android.kt
+++ b/core/src/androidMain/kotlin/com/hussienFahmy/core/domain/report/ReportBrandingProvider.android.kt
@@ -1,0 +1,56 @@
+package com.hussienfahmy.core.domain.report
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.util.Base64
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.createBitmap
+import com.hussienfahmy.core.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.context.GlobalContext
+import java.io.ByteArrayOutputStream
+
+actual class ReportBrandingProvider(private val context: Context) {
+    actual suspend fun loadAppIconBase64Png(): String? = withContext(Dispatchers.IO) {
+        try {
+            val drawable = context.packageManager.getApplicationIcon(context.packageName)
+            drawableToBase64Png(drawable, fallbackSize = 192)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    actual suspend fun loadQrCodeBase64Png(): String? = withContext(Dispatchers.IO) {
+        try {
+            val drawable = ResourcesCompat.getDrawable(context.resources, R.drawable.qr_code, null)!!
+            drawableToBase64Png(drawable, fallbackSize = 256)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun drawableToBase64Png(drawable: Drawable, fallbackSize: Int): String {
+        val bitmap = when (drawable) {
+            is BitmapDrawable -> drawable.bitmap
+            else -> {
+                val w = drawable.intrinsicWidth.takeIf { it > 0 } ?: fallbackSize
+                val h = drawable.intrinsicHeight.takeIf { it > 0 } ?: fallbackSize
+                val bm = createBitmap(w, h)
+                val canvas = Canvas(bm)
+                drawable.setBounds(0, 0, w, h)
+                drawable.draw(canvas)
+                bm
+            }
+        }
+        val stream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+        return Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP)
+    }
+}
+
+actual fun createReportBrandingProvider(): ReportBrandingProvider =
+    ReportBrandingProvider(GlobalContext.get().get())

--- a/core/src/commonMain/kotlin/com/hussienFahmy/core/domain/report/PdfReportPrinter.kt
+++ b/core/src/commonMain/kotlin/com/hussienFahmy/core/domain/report/PdfReportPrinter.kt
@@ -1,0 +1,9 @@
+package com.hussienfahmy.core.domain.report
+
+// iOS actual (WKWebView + UIPrintPageRenderer/UIGraphicsPDFRenderer, the direct analog of
+// Android's WebView+PrintManager) is deferred to the iOS phase, since nothing consumes it yet.
+expect class PdfReportPrinter {
+    fun print(html: String, title: String)
+}
+
+expect fun createPdfReportPrinter(): PdfReportPrinter

--- a/core/src/commonMain/kotlin/com/hussienFahmy/core/domain/report/ReportBrandingProvider.kt
+++ b/core/src/commonMain/kotlin/com/hussienFahmy/core/domain/report/ReportBrandingProvider.kt
@@ -1,0 +1,10 @@
+package com.hussienfahmy.core.domain.report
+
+// Loads the app icon / QR code as base64-encoded PNGs for embedding into the exported academic
+// report HTML. iOS actual is deferred to the iOS phase, since nothing consumes it yet.
+expect class ReportBrandingProvider {
+    suspend fun loadAppIconBase64Png(): String?
+    suspend fun loadQrCodeBase64Png(): String?
+}
+
+expect fun createReportBrandingProvider(): ReportBrandingProvider

--- a/semester_history/semester_history_domain/src/main/java/com/hussienfahmy/semester_history_domain/di/Module.kt
+++ b/semester_history/semester_history_domain/src/main/java/com/hussienfahmy/semester_history_domain/di/Module.kt
@@ -13,8 +13,8 @@ import com.hussienfahmy.semester_history_domain.use_case.GenerateAcademicReport
 import com.hussienfahmy.semester_history_domain.use_case.GetSemesterDetail
 import com.hussienfahmy.semester_history_domain.use_case.GetSemesterHistory
 import com.hussienfahmy.semester_history_domain.use_case.GetWorkspaceSubjectCount
+import com.hussienfahmy.core.domain.report.createReportBrandingProvider
 import com.hussienfahmy.semester_history_domain.use_case.ReorderSemester
-import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val semesterHistoryDomainModule = module {
@@ -45,7 +45,7 @@ val semesterHistoryDomainModule = module {
             userDataRepository = get(),
             gpaSettingsRepository = get(),
             registry = get(),
-            context = androidContext(),
+            brandingProvider = createReportBrandingProvider(),
         )
     }
     single {

--- a/semester_history/semester_history_domain/src/main/java/com/hussienfahmy/semester_history_domain/use_case/GenerateAcademicReport.kt
+++ b/semester_history/semester_history_domain/src/main/java/com/hussienfahmy/semester_history_domain/use_case/GenerateAcademicReport.kt
@@ -1,14 +1,5 @@
 package com.hussienfahmy.semester_history_domain.use_case
 
-import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.drawable.BitmapDrawable
-import android.util.Base64
-import androidx.annotation.DrawableRes
-import androidx.core.content.res.ResourcesCompat
-import androidx.core.graphics.createBitmap
-import com.hussienfahmy.core.generated.resources.Res
 import com.hussienfahmy.core.data.local.GradeDao
 import com.hussienfahmy.core.data.local.SemesterDao
 import com.hussienfahmy.core.data.local.SubjectDao
@@ -16,16 +7,14 @@ import com.hussienfahmy.core.data.local.entity.Subject
 import com.hussienfahmy.core.domain.gpa_settings.repository.GPASettingsRepository
 import com.hussienfahmy.core.domain.report.AcademicReportData
 import com.hussienfahmy.core.domain.report.GradeThreshold
+import com.hussienfahmy.core.domain.report.ReportBrandingProvider
 import com.hussienfahmy.core.domain.report.ReportTemplate
 import com.hussienfahmy.core.domain.report.ReportTemplateRegistry
 import com.hussienfahmy.core.domain.report.SemesterSection
 import com.hussienfahmy.core.domain.report.SubjectRow
 import com.hussienfahmy.core.domain.user_data.repository.UserDataRepository
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withContext
-import java.io.ByteArrayOutputStream
 
 class GenerateAcademicReport(
     private val subjectDao: SubjectDao,
@@ -34,7 +23,7 @@ class GenerateAcademicReport(
     private val userDataRepository: UserDataRepository,
     private val gpaSettingsRepository: GPASettingsRepository,
     private val registry: ReportTemplateRegistry,
-    private val context: Context,
+    private val brandingProvider: ReportBrandingProvider,
 ) {
     suspend operator fun invoke(template: ReportTemplate = ReportTemplate.DEFAULT): String {
         val userData = userDataRepository.userData.filterNotNull().first()
@@ -78,58 +67,12 @@ class GenerateAcademicReport(
             currentSemester = null,
             history = historySections,
             grades = gradeThresholds,
-            logoBase64Png = loadLauncherLogoBase64(),
-            qrBase64Png = loadDrawableBase64(R.drawable.qr_code),
+            logoBase64Png = brandingProvider.loadAppIconBase64Png(),
+            qrBase64Png = brandingProvider.loadQrCodeBase64Png(),
         )
 
         return registry.render(template, reportData)
     }
-
-    private suspend fun loadLauncherLogoBase64(): String? = withContext(Dispatchers.IO) {
-        try {
-            val drawable = context.packageManager.getApplicationIcon(context.packageName)
-            val bitmap = when (drawable) {
-                is BitmapDrawable -> drawable.bitmap
-                else -> {
-                    val size = 192
-                    val bm = createBitmap(size, size)
-                    val canvas = Canvas(bm)
-                    drawable.setBounds(0, 0, size, size)
-                    drawable.draw(canvas)
-                    bm
-                }
-            }
-            val stream = ByteArrayOutputStream()
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
-            Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP)
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    private suspend fun loadDrawableBase64(@DrawableRes resId: Int): String? =
-        withContext(Dispatchers.IO) {
-            try {
-                val drawable = ResourcesCompat.getDrawable(context.resources, resId, null)!!
-                val bitmap = when (drawable) {
-                    is BitmapDrawable -> drawable.bitmap
-                    else -> {
-                        val w = drawable.intrinsicWidth.takeIf { it > 0 } ?: 256
-                        val h = drawable.intrinsicHeight.takeIf { it > 0 } ?: 256
-                        val bm = createBitmap(w, h)
-                        val canvas = Canvas(bm)
-                        drawable.setBounds(0, 0, w, h)
-                        drawable.draw(canvas)
-                        bm
-                    }
-                }
-                val stream = ByteArrayOutputStream()
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
-                Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP)
-            } catch (_: Exception) {
-                null
-            }
-        }
 
     private fun Subject.toSubjectRow(
         gradesMap: Map<com.hussienfahmy.core.data.local.model.GradeName, com.hussienfahmy.core.data.local.entity.Grade>,


### PR DESCRIPTION
## Summary

Phase 4c of the KMP/CMP migration plan (stacked on #24 / branch `multiplatform-phase4b-uploadphoto-expect-actual`).

Per explicit confirmation, introduces both `expect`/`actual` abstractions now rather than deferring to the iOS phase.

- **`PdfReportPrinter`** (commonMain) replaces `WebViewPdfPrinter` (deleted). The Android `actual` is a straight relocation of the existing WebView + PrintManager logic. iOS's `actual` (`WKWebView` + `UIPrintPageRenderer`/`UIGraphicsPDFRenderer`, the direct analog of Android's approach) is deferred to the iOS phase. `AppSemesterHistoryScreen.kt`'s single call site updates from `WebViewPdfPrinter.print(context, html, title)` to `createPdfReportPrinter().print(html, title)`, following the same `GlobalContext` factory pattern as the other `:core` expect/actuals so far.
- **`ReportBrandingProvider`** (commonMain) replaces `GenerateAcademicReport`'s two private `PackageManager`/`Bitmap`/`Canvas`/`Base64` helper methods (`loadLauncherLogoBase64`/`loadDrawableBase64`) with `loadAppIconBase64Png()`/`loadQrCodeBase64Png()`. The Android `actual` relocates the same drawable-to-base64-PNG logic, deduplicated into one shared private helper. `GenerateAcademicReport` no longer takes a raw `Context` - it takes the injected `ReportBrandingProvider` instead, wired via `createReportBrandingProvider()` in its Koin module (dropping the `androidContext()` call).

## Note on verification

Unverified in this sandbox - no Android SDK, Gradle 9.3.1 blocked by network policy.

## Test plan

- [ ] `./gradlew :core:compileDebugKotlinAndroid`, `:semester_history_domain:compileDebugKotlin`, `:app:assembleDebug` succeed
- [ ] Export an academic report PDF end-to-end (print dialog opens, PDF looks correct)
- [ ] Exported report still shows the app icon logo and QR code correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018X7zSzCGkBBuUxpDW4LcWQ)_