### PR TITLE
KMP migration Phase 7c: Storage to GitLive Firebase-Kotlin-SDK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,11 +119,11 @@ dependencies {
     implementation(libs.androidx.profileinstaller)
     baselineProfile(project(":baselineprofile"))
 
-    // Firebase (Firestore migrated to GitLive; Auth/Storage/Analytics migrate in follow-up
+    // Firebase (Firestore + Storage migrated to GitLive; Auth/Analytics migrate in follow-up
     // sub-PRs, still on the Android SDK for now)
     implementation(libs.gitlive.firebase.firestore)
+    implementation(libs.gitlive.firebase.storage)
     implementation(libs.firebase.auth)
-    implementation(libs.firebase.storage)
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.inappmessaging)

--- a/app/src/main/java/com/hussienFahmy/myGpaManager/data/storage/FirebaseStorageRepository.kt
+++ b/app/src/main/java/com/hussienFahmy/myGpaManager/data/storage/FirebaseStorageRepository.kt
@@ -1,9 +1,9 @@
 package com.hussienfahmy.myGpaManager.data.storage
 
-import com.google.firebase.storage.FirebaseStorage
 import com.hussienfahmy.core.domain.storage.repository.StorageRepository
 import com.hussienfahmy.myGpaManager.data.user_data.model.FirebaseUserData
-import kotlinx.coroutines.tasks.await
+import dev.gitlive.firebase.storage.Data
+import dev.gitlive.firebase.storage.FirebaseStorage
 
 class FirebaseStorageRepository(
     private val storage: FirebaseStorage
@@ -11,35 +11,25 @@ class FirebaseStorageRepository(
 
     override suspend fun uploadUserPhoto(userId: String, imageData: ByteArray): String {
         val photoRef = storage.reference.child("${FirebaseUserData.USERS_COLLECTION_NAME}/$userId")
-
-        val uploadTask = photoRef.putBytes(imageData)
-
-        return uploadTask.continueWithTask { task ->
-            if (!task.isSuccessful) {
-                task.exception?.let { throw it }
-            }
-            photoRef.downloadUrl
-        }.await().toString()
+        // FLAG FOR REVIEW: Data(imageData)'s exact Android constructor signature could not be
+        // fully verified against GitLive's source in this sandbox (conflicting fetch results) -
+        // double check this against the actual dev.gitlive.firebase.storage.Data class before
+        // relying on it.
+        photoRef.putData(Data(imageData))
+        return photoRef.getDownloadUrl()
     }
 
     override suspend fun uploadFile(path: String, data: ByteArray): String {
         val fileRef = storage.reference.child(path)
-
-        val uploadTask = fileRef.putBytes(data)
-
-        return uploadTask.continueWithTask { task ->
-            if (!task.isSuccessful) {
-                task.exception?.let { throw it }
-            }
-            fileRef.downloadUrl
-        }.await().toString()
+        fileRef.putData(Data(data))
+        return fileRef.getDownloadUrl()
     }
 
     override suspend fun downloadUrl(path: String): String {
-        return storage.reference.child(path).downloadUrl.await().toString()
+        return storage.reference.child(path).getDownloadUrl()
     }
 
     override suspend fun deleteFile(path: String) {
-        storage.reference.child(path).delete().await()
+        storage.reference.child(path).delete()
     }
 }

--- a/app/src/main/java/com/hussienFahmy/myGpaManager/di/FirebaseModule.kt
+++ b/app/src/main/java/com/hussienFahmy/myGpaManager/di/FirebaseModule.kt
@@ -4,8 +4,6 @@ import androidx.credentials.CredentialManager
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.auth
-import com.google.firebase.storage.FirebaseStorage
-import com.google.firebase.storage.storage
 import com.hussienfahmy.core.domain.auth.repository.AuthRepository
 import com.hussienfahmy.core.domain.auth.service.AuthService
 import com.hussienfahmy.core.domain.storage.repository.StorageRepository
@@ -20,18 +18,20 @@ import com.hussienfahmy.sync_domain.repository.SyncRepository
 import dev.gitlive.firebase.Firebase as GitLiveFirebase
 import dev.gitlive.firebase.firestore.FirebaseFirestore as GitLiveFirebaseFirestore
 import dev.gitlive.firebase.firestore.firestore as gitLiveFirestore
+import dev.gitlive.firebase.storage.FirebaseStorage as GitLiveFirebaseStorage
+import dev.gitlive.firebase.storage.storage as gitLiveStorage
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val firebaseModule = module {
-    // Firestore migrated to the GitLive Firebase-Kotlin-SDK (multiplatform, kotlinx.serialization
-    // -based) - Auth/Storage below are still the Android Firebase SDK, migrated in their own
-    // follow-up sub-PRs. Dropped the persistent-cache-size customization (previously
-    // CACHE_SIZE_UNLIMITED) since GitLive's settings API differs; defaults still provide offline
-    // caching, just not explicitly unlimited-sized - flagged as a deliberate simplification to
-    // revisit if offline cache size turns out to matter in practice.
+    // Firestore and Storage migrated to the GitLive Firebase-Kotlin-SDK (multiplatform,
+    // kotlinx.serialization-based) - Auth below is still the Android Firebase SDK, migrated in
+    // its own follow-up sub-PR. Dropped the Firestore persistent-cache-size customization
+    // (previously CACHE_SIZE_UNLIMITED) since GitLive's settings API differs; defaults still
+    // provide offline caching, just not explicitly unlimited-sized - flagged as a deliberate
+    // simplification to revisit if offline cache size turns out to matter in practice.
     single<GitLiveFirebaseFirestore> {
         GitLiveFirebase.gitLiveFirestore
     }
@@ -40,7 +40,8 @@ val firebaseModule = module {
         Firebase.auth
     }
 
-    single<FirebaseStorage> { Firebase.storage }
+    // Storage migrated to GitLive too (Phase 7c) - Auth stays Android SDK for now.
+    single<GitLiveFirebaseStorage> { GitLiveFirebase.gitLiveStorage }
 
     // Repository implementations
     single<AuthRepository> {


### PR DESCRIPTION
## Summary

Phase 7c of the KMP/CMP migration plan (stacked on #29 / branch `multiplatform-phase7a-firestore-gitlive`). Per the migration plan's per-product sub-PR approach - Auth and Analytics still remain on the Android SDK, migrated separately.

`FirebaseStorageRepository` now takes `dev.gitlive.firebase.storage.FirebaseStorage` instead of the Android SDK type; the four methods (`uploadUserPhoto`/`uploadFile`/`downloadUrl`/`deleteFile`) map directly onto GitLive's `StorageReference` API (`child`/`putData`/`getDownloadUrl`/`delete`).

**⚠️ FLAGGED FOR REVIEW**: `dev.gitlive.firebase.storage.Data`'s exact Android constructor signature could not be fully verified against GitLive's source in this sandbox (the fetch tool returned self-contradictory results for this one file - flagging rather than guessing silently). Written as `Data(byteArray)` as the most likely shape; **double-check against the actual class before relying on it.**

`FirebaseModule.kt`'s Storage singleton switches from `Firebase.storage` (Android SDK) to GitLive's `Firebase.storage`; Auth is untouched. `app/build.gradle.kts` swaps `firebase.storage` for `gitlive.firebase.storage`.

## Note on verification

Unverified in this sandbox - no Android SDK, Gradle 9.3.1 blocked by network policy. **Please build-verify AND test photo upload / general file upload end-to-end before merging, with particular attention to the flagged `Data` constructor.**

## Test plan

- [ ] `./gradlew :app:compileDebugKotlin` succeeds - especially the `Data(imageData)` construction
- [ ] Profile photo upload end-to-end (picker → thumbnail → Storage upload → download URL → profile updates)
- [ ] Storage file delete works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018X7zSzCGkBBuUxpDW4LcWQ)_