### PR TITLE
Phase 12: remove dead dependencies left over from the migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,10 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
-    // Needed for the new @Serializable Firestore DTOs (FirebaseNetworkSemester,
-    // FirebaseUserData, etc.) - GitLive Firestore is kotlinx.serialization-based - and now also
-    // for the @Serializable Navigation 3 route keys (AppRoute/OnboardingRoute).
-    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.androidx.baselineprofile)
@@ -92,7 +88,6 @@ dependencies {
 
     // Koin
     implementation(libs.koin.android)
-    implementation(libs.koin.androidx.compose)
     implementation(libs.koin.androidx.worker)
 
     // Kotlin BOM
@@ -108,11 +103,6 @@ dependencies {
     implementation(libs.bundles.compose)
     implementation(libs.bundles.compose.debug)
     implementation(libs.bundles.compose.presentation)
-
-    // Navigation 3 (Phase 8 - replaces Compose Destinations)
-    implementation(libs.androidx.navigation3.runtime)
-    implementation(libs.androidx.navigation3.ui)
-    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
 
     // Work Manager
     implementation(libs.androidx.work.runtime.ktx)

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -32,14 +32,6 @@ kotlin {
             implementation(libs.coil3.network.ktor)
             implementation(libs.ktor.client.darwin)
         }
-
-        // iOS has no ServiceLoader-style auto-discovery, so it needs an explicit
-        // SingletonImageLoader.setSafe { ... } with a Ktor/Darwin-backed fetcher registered - see
-        // CoilImageLoader.ios.kt, called from :shared's doInitKoin() now that iosApp/ exists.
-        iosMain.dependencies {
-            implementation(libs.coil3.network.ktor)
-            implementation(libs.ktor.client.darwin)
-        }
     }
 }
 

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -32,6 +32,14 @@ kotlin {
             implementation(libs.coil3.network.ktor)
             implementation(libs.ktor.client.darwin)
         }
+
+        // iOS has no ServiceLoader-style auto-discovery, so it needs an explicit
+        // SingletonImageLoader.setSafe { ... } with a Ktor/Darwin-backed fetcher registered - see
+        // CoilImageLoader.ios.kt, called from :shared's doInitKoin() now that iosApp/ exists.
+        iosMain.dependencies {
+            implementation(libs.coil3.network.ktor)
+            implementation(libs.ktor.client.darwin)
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,14 +33,12 @@ espressoCore = "3.7.0"
 
 # Compose
 composeBom = "2026.02.01"
-composeIconsAndroid = "1.0.0"
 material-icons = "1.7.8"
 
 # Koin
 koin = "4.1.1"
 
 # Third Party Libraries
-coil = "2.7.0"
 mockk = "1.14.9"
 
 # Firebase
@@ -147,9 +145,6 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core", version.ref = "material-icons" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "material-icons" }
 
-# Third Party Compose Icons
-compose-icons-font-awesome = { group = "br.com.devsrsouza.compose.icons.android", name = "font-awesome", version.ref = "composeIconsAndroid" }
-
 # Kotlin
 kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlinBom" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
@@ -159,7 +154,6 @@ kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime",
 # Koin
 koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
-koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
 koin-androidx-worker = { group = "io.insert-koin", name = "koin-androidx-workmanager", version.ref = "koin" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose", version.ref = "koin" }
 koin-compose-viewmodel = { group = "io.insert-koin", name = "koin-compose-viewmodel", version.ref = "koin" }
@@ -167,19 +161,16 @@ koin-test = { group = "io.insert-koin", name = "koin-test", version.ref = "koin"
 koin-test-junit4 = { group = "io.insert-koin", name = "koin-test-junit4", version.ref = "koin" }
 
 # Third Party
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
-# Coil 3 (multiplatform) - added for the core-ui KMP migration phase, not wired in yet
 coil3-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil3" }
 coil3-network-ktor = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil3" }
-# OkHttp-backed network engine - used instead of coil3-network-ktor while Coil consumers are
-# still Android-only (no Ktor client engine artifact configured yet); switch to the ktor3 engine
-# above once these move to commonMain for iOS.
+# OkHttp-backed network engine, used on Android only (auto-discovered via Coil's JVM-only
+# ServiceLoader mechanism); iOS uses coil3-network-ktor + ktor-client-darwin instead.
 coil3-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil3" }
 # iOS's coil3 network engine - Ktor's Darwin (NSURLSession-backed) client engine.
 ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }
 
-# Compose Destinations
-# Jetpack Navigation 3 (multiplatform) - wired into :app in Phase 8, replacing Compose Destinations
+# Jetpack Navigation 3 (multiplatform) - replaced Compose Destinations in Phase 8; the app-level
+# nav host lives in :shared as of Phase 11 (see shared/build.gradle.kts)
 androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
 androidx-lifecycle-viewmodel-navigation3 = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-navigation3", version.ref = "androidxLifecycle" }


### PR DESCRIPTION
## Summary

Verified each removal via repo-wide grep before deleting (zero remaining references), not just from local reasoning:

- **Coil 2** (`coil`, `coil-compose` aliases): fully replaced by Coil 3 as of Phase 11e — no `io.coil-kt` (v2) imports remain anywhere.
- **FontAwesome Compose Icons** (`composeIconsAndroid`, `compose-icons-font-awesome`): the app already only uses `androidx.compose.material.icons` (genuinely multiplatform) — this Android-only dependency, flagged as a migration blocker back in the original plan's Phase 5, turned out to have zero actual usages left to migrate.
- **`koin-androidx-compose`**: superseded by the multiplatform `koin-compose-viewmodel` everywhere, including in `:app` itself now that `MainActivity.kt` no longer injects `MainViewModel` directly (that moved into `:shared`'s `GpaManagerApp` via the multiplatform `koinViewModel()`).
- **`:app`'s `kotlin.serialization` plugin + Navigation 3 dependencies**: both were only ever needed for code that has since moved to `:shared` (Firestore DTOs, `AppRoute`/`OnboardingRoute`, `AppNavHost`/`OnboardingNavHost`) — `:shared`'s own `base_kmp_module` convention plugin already applies `kotlin.serialization` and declares navigation3 itself.

Also fixed two now-stale comments in the version catalog referencing already-completed migration steps.

**Deliberately not touched** (per the original migration plan, which explicitly marks these "not required" for the migration itself): the pre-existing `com.hussienFahmy` vs `com.hussienfahmy` package-name inconsistency, and the `semester_subjctets`/`gpa_system_settings_presentaion` folder-name typos.

## Note on verification

Unverified in this sandbox — no working Gradle version or Android SDK here. Every removal was checked via grep for zero remaining usages, but that's not a substitute for actually running the build.

## Test plan

- [ ] `./gradlew :app:assembleDebug` still succeeds
- [ ] `./gradlew build` (full project) succeeds with no unresolved dependency errors

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018X7zSzCGkBBuUxpDW4LcWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018X7zSzCGkBBuUxpDW4LcWQ)_