### PR TITLE
fix: app never compiled + two runtime crashes (verified on device)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.crashlytics)
@@ -112,6 +113,7 @@ dependencies {
     baselineProfile(project(":baselineprofile"))
 
     // Firebase (Firestore + Storage + Analytics + Auth all migrated to GitLive)
+    implementation(platform(libs.firebase.bom))
     implementation(libs.gitlive.firebase.firestore)
     implementation(libs.gitlive.firebase.storage)
     implementation(libs.gitlive.firebase.analytics)

--- a/app/src/main/java/com/hussienFahmy/myGpaManager/di/FirebaseModule.kt
+++ b/app/src/main/java/com/hussienFahmy/myGpaManager/di/FirebaseModule.kt
@@ -1,3 +1,8 @@
+// Same package + file name as :shared's own di/FirebaseModule.kt would otherwise both compile to
+// the identical facade class com.hussienfahmy.myGpaManager.di.FirebaseModuleKt - whichever
+// module's dex wins the merge silently shadows the other's. Disambiguated explicitly.
+@file:JvmName("AppFirebaseModule")
+
 package com.hussienfahmy.myGpaManager.di
 
 import androidx.credentials.CredentialManager

--- a/app/src/main/java/com/hussienFahmy/myGpaManager/di/FirebaseModule.kt
+++ b/app/src/main/java/com/hussienFahmy/myGpaManager/di/FirebaseModule.kt
@@ -6,7 +6,8 @@ import com.hussienfahmy.core.domain.auth.service.AuthSignIn
 import com.hussienfahmy.myGpaManager.data.auth.GoogleAuthService
 import com.hussienfahmy.myGpaManager.data.auth.GoogleAuthUiClient
 import org.koin.android.ext.koin.androidContext
-import org.koin.dsl.bind
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 // The GitLive Firebase singletons + AuthRepository/StorageRepository/UserDataRepository/
@@ -27,5 +28,8 @@ val firebaseModule = module {
         )
     }
 
-    single { GoogleAuthService(get()) } bind AuthService::class bind AuthSignIn::class
+    // .bind<T>() narrows the KoinDefinition to T on return, so chaining two of them fails once
+    // AuthService and AuthSignIn are unrelated sibling interfaces (the second bind can't see the
+    // original GoogleAuthService type anymore) - binds(Array<KClass<*>>) sets both without narrowing.
+    singleOf(::GoogleAuthService).binds(arrayOf(AuthService::class, AuthSignIn::class))
 }

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.test)
+    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.androidx.baselineprofile)
 }
 

--- a/core-ui/src/commonMain/composeResources/drawable/baseline_person_24.xml
+++ b/core-ui/src/commonMain/composeResources/drawable/baseline_person_24.xml
@@ -5,6 +5,6 @@
     android:width="24dp"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <path
-        android:fillColor="@android:color/white"
+        android:fillColor="#FFFFFF"
         android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z" />
 </vector>

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -45,6 +45,11 @@ kotlin {
         }
 
         androidMain.dependencies {
+            // Supplies the version for firebase-analytics (unversioned) that
+            // gitlive.firebase.analytics's Android artifact pulls in transitively.
+            // project.dependencies.platform(...), not the bare platform(...) DSL extension - that
+            // overload is broken inside KMP sourceSet dependency blocks under Kotlin 2.3 (KT-58759).
+            implementation(project.dependencies.platform(libs.firebase.bom))
             implementation(libs.androidx.core.ktx)
             implementation(libs.androidx.activity.ktx)
             implementation(libs.koin.android)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ koin = "4.1.1"
 mockk = "1.14.9"
 
 # Firebase
+firebaseBom = "34.16.0"
 firebaseAuth = "23.2.1"
 firebaseFirestore = "25.1.4"
 firebaseStorage = "22.0.1"
@@ -187,6 +188,10 @@ gitlive-firebase-storage = { group = "dev.gitlive", name = "firebase-storage", v
 gitlive-firebase-analytics = { group = "dev.gitlive", name = "firebase-analytics", version.ref = "gitliveFirebase" }
 
 # Firebase
+# BOM supplies versions for firebase-firestore/storage/analytics/auth (unversioned as of the
+# KTX-merge era) that GitLive's Android artifacts pull in transitively - without this, those
+# transitive deps have no version anywhere and fail to resolve.
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuth" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestore" }
 firebase-storage = { group = "com.google.firebase", name = "firebase-storage", version.ref = "firebaseStorage" }
@@ -218,6 +223,16 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+# android.builtInKotlin=false in gradle.properties disables AGP's built-in Kotlin compiler
+# project-wide (needed so the KMP library modules don't conflict with com.android.library under
+# AGP 9 - see BaseKmpModulePlugin). :app and :baselineprofile are plain com.android.application/
+# com.android.test modules with no KMP involvement, so with the built-in compiler off they need
+# this applied explicitly or their own .kt sources never get compiled at all.
+# No version.ref: AGP's built-in Kotlin machinery already puts this plugin's marker on the
+# buildscript classpath even with android.builtInKotlin=false, so pinning our own version here
+# conflicts ("already on the classpath with an unknown version"). Let it resolve against
+# whatever's already present.
+kotlin-android = { id = "org.jetbrains.kotlin.android" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -27,6 +27,12 @@ kotlin {
         // the other Phase 11 iOS stubs. Revisit once there's a real iOS app shell and either
         // Navigation 3 or its own nav host to hand this off to.
         androidMain.dependencies {
+            // Supplies versions for firebase-firestore/storage/auth (unversioned) that the
+            // gitlive.firebase.* Android artifacts below pull in transitively.
+            // project.dependencies.platform(...), not the bare platform(...) DSL extension - that
+            // overload is broken inside KMP sourceSet dependency blocks under Kotlin 2.3 (KT-58759).
+            implementation(project.dependencies.platform(libs.firebase.bom))
+
             implementation(project(":core"))
             implementation(project(":core-ui"))
 

--- a/shared/src/androidMain/kotlin/com/hussienfahmy/myGpaManager/data/user_data/model/FirebaseUserData.kt
+++ b/shared/src/androidMain/kotlin/com/hussienfahmy/myGpaManager/data/user_data/model/FirebaseUserData.kt
@@ -1,7 +1,31 @@
 package com.hussienfahmy.myGpaManager.data.user_data.model
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+// Accounts created before the Phase 7a Firebase migration have createdAt/updatedAt stored as a
+// native Firestore Timestamp (the pre-migration Android SDK's server-timestamp type), not the
+// epoch-millis Long this migration switched to (see TimestampMapper.kt for why). Neither field is
+// read anywhere downstream - they're write-only bookkeeping - so on a legacy Timestamp-shaped
+// document there's nothing to recover; just don't let it crash the whole document decode.
+private object LenientEpochMillisSerializer : KSerializer<Long> {
+    override val descriptor = PrimitiveSerialDescriptor("LenientEpochMillis", PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: Long) = encoder.encodeLong(value)
+
+    override fun deserialize(decoder: Decoder): Long {
+        return try {
+            decoder.decodeLong()
+        } catch (e: Exception) {
+            0L
+        }
+    }
+}
 
 // No id/@DocumentId field: the document id is always the Firebase Auth uid already known to the
 // caller (userDoc(userId) = .document(userId)), so it's redundant to also store/read it from the
@@ -14,7 +38,9 @@ internal data class FirebaseUserData(
     @SerialName(PROPERTY_ACADEMIC_INFO) val academicInfo: AcademicInfo = AcademicInfo(),
     @SerialName(PROPERTY_FCM_TOKEN) val fcmToken: String = "",
     @SerialName(PROPERTY_ACADEMIC_PROGRESS) val academicProgress: AcademicProgress = AcademicProgress(),
+    @Serializable(with = LenientEpochMillisSerializer::class)
     @SerialName(PROPERTY_CREATED_AT) val createdAt: Long? = null,
+    @Serializable(with = LenientEpochMillisSerializer::class)
     @SerialName(PROPERTY_UPDATED_AT) val updatedAt: Long? = null,
 ) {
     @Serializable

--- a/shared/src/androidMain/kotlin/com/hussienfahmy/myGpaManager/di/FirebaseModule.kt
+++ b/shared/src/androidMain/kotlin/com/hussienfahmy/myGpaManager/di/FirebaseModule.kt
@@ -1,3 +1,9 @@
+// Same package + file name as :app's own di/FirebaseModule.kt would otherwise both compile to
+// the identical facade class com.hussienfahmy.myGpaManager.di.FirebaseModuleKt - whichever
+// module's dex wins the merge silently shadows the other's, so :app's firebaseModule vanishes
+// at runtime (NoSuchMethodError) with zero build-time warning. Disambiguated explicitly.
+@file:JvmName("SharedFirebaseModule")
+
 package com.hussienfahmy.myGpaManager.di
 
 import com.hussienfahmy.core.domain.auth.repository.AuthRepository


### PR DESCRIPTION
## Summary

Follow-up on top of the phase12 cleanup-dead-deps branch. Found and fixed four bugs while chasing a runtime crash report, three of which were completely invisible to the build all session:

1. **`:app`/`:baselineprofile` had no Kotlin compiler wired in at all.** `android.builtInKotlin=false` in `gradle.properties` (needed project-wide so the KMP library modules don't conflict with `com.android.library` under AGP 9) also disabled AGP's built-in Kotlin compiler for `:app` and `:baselineprofile`, which are plain `com.android.application`/`com.android.test` modules that never separately applied `org.jetbrains.kotlin.android`. Every `.kt` file in both modules was silently never compiled - masked by a stale dex cache from before this regressed. A `:app:clean` exposed it as `ClassNotFoundException` on `GPAManagerApplication` at launch. Fixed by applying `org.jetbrains.kotlin.android` explicitly (unversioned - it's already implicitly on the classpath via AGP's built-in Kotlin machinery, so pinning a version conflicts).

2. **GitLive's Android Firebase artifacts don't resolve without a Firebase BOM.** firestore/storage/analytics/auth transitively depend on the real `com.google.firebase:firebase-*` base artifacts, which are unversioned (BOM-managed) as of the KTX-merge era. No BOM was applied anywhere. Added it to `:core`, `:shared`, `:app`.

3. **`FirebaseModuleKt` class collision.** `:app`'s and `:shared`'s `di/FirebaseModule.kt` are both in the same package with the same file name, so both compiled to the identical facade class. Whichever module's dex won the merge silently shadowed the other's - `:app`'s `firebaseModule` property didn't exist at runtime (`NoSuchMethodError`, immediate crash on launch, zero build-time signal). Disambiguated both via `@file:JvmName`.

4. **Legacy Firestore documents crash on decode.** Accounts created before the Phase 7a Firebase migration have `createdAt`/`updatedAt` stored as a native Firestore `Timestamp`; this migration switched to a client-computed epoch-millis `Long` but never handled documents already in the old shape. Neither field is read anywhere downstream, so added a lenient `KSerializer` that falls back instead of crashing the whole document decode.

Also fixed the underlying Koin DI bug the first fix exposed: `FirebaseModule.kt` bound `GoogleAuthService` to two unrelated sibling interfaces via a `bind` chain that narrows on each call (breaks past the first bind); switched to `binds(arrayOf(...))`.

## Test plan

- [x] `./gradlew :app:assembleDebug` - clean, no cache tricks
- [x] Verified `GPAManagerApplication`/`MainActivity`/etc. actually present in the built APK's dex (grepped for the class names post-build, not just "build succeeded")
- [x] Installed on a connected physical device, launched with a real signed-in account, watched logcat through the full launch - no crash, process stayed alive for several minutes
- [ ] Full golden-path walkthrough (sign-in → onboarding → semester CRUD → sync) - not yet done, recommended next

🤖 Generated with [Claude Code](https://claude.com/claude-code)